### PR TITLE
Fix multi-line string dumping

### DIFF
--- a/lib/lyaml.lua
+++ b/lib/lyaml.lua
@@ -131,6 +131,8 @@ local dumper_mt = {
         style = "SINGLE_QUOTED"
       elseif itsa == "number" or itsa == "boolean" then
         value = tostring (value)
+      elseif itsa == "string" and string.find (value, "\n") then
+        style = "LITERAL"
       end
       return self:emit {
         type            = "SCALAR",

--- a/specs/lib_lyaml_spec.yaml
+++ b/specs/lib_lyaml_spec.yaml
@@ -37,6 +37,7 @@ specify lyaml:
     - it writes strings:
         expect (lyaml.dump {"a string"}).to_be "--- a string\n...\n"
         expect (lyaml.dump {"'a string'"}).to_be "--- '''a string'''\n...\n"
+        expect (lyaml.dump {"a\nmultiline\nstring"}).to_be "--- |-\n  a\n  multiline\n  string\n...\n"
 
   - context sequences:
     - it writes a sequence:
@@ -140,6 +141,7 @@ specify lyaml:
     - it recognizes strings:
         expect (lyaml.load "a string").to_equal {"a string"}
         expect (lyaml.load "'''a string'''").to_equal {"'a string'"}
+        expect (lyaml.load "|-\n  a\n  multiline\n  string").to_equal {"a\nmultiline\nstring"}
 
     - context global tags:
       - it recognizes !!bool:


### PR DESCRIPTION
Multi-line strings were previously being dumped using single quotes which caused the dumped YAML to break.

For example, `{ foo = "a\nmultiline\nstring" }` would get dumped as:

```yaml
foo: 'a

  multiline

  string'
```

Note the extra line-breaks in between each line. This also causes YAML parsing to fail (since the blank lines didn't have the expected indentation).

This patch fixes the dump to use the YAML literal syntax for any multi-line strings so the same example gets dumped as:

```yaml
foo: |-
  a
  multiline
  string
```