### PR TITLE
Fix empty values so they are parsed as null values, not empty strings

### DIFF
--- a/lib/lyaml.lua
+++ b/lib/lyaml.lua
@@ -127,7 +127,8 @@ local dumper_mt = {
       local style = "PLAIN"
       if value == "true" or value == "false" or
          value == "yes" or value == "no" or value == "~" or
-         (type (value) ~= "number" and tonumber (value) ~= nil) then
+         (type (value) ~= "number" and tonumber (value) ~= nil) or
+         value == "" then
         style = "SINGLE_QUOTED"
       elseif value == math.huge then
 	value = ".inf"
@@ -437,6 +438,8 @@ local parser_mt = {
       -- Otherwise, implicit conversion according to value content.
       elseif self.event.style == "PLAIN" then
         if value == "~" then
+          value = null
+        elseif value == "" then
           value = null
         elseif istruthy[value] then
           value = true

--- a/specs/lib_lyaml_spec.yaml
+++ b/specs/lib_lyaml_spec.yaml
@@ -13,7 +13,7 @@ specify lyaml:
 
   - context documents:
     - it writes an empty document:
-        expect (lyaml.dump {""}).to_match "^%-%-%-%s*\n%.%.%.%s*$"
+        expect (lyaml.dump {""}).to_match "^%-%-%-%s*''\n%.%.%.%s*$"
     - it writes consecutive documents:
         expect (lyaml.dump {"one", "two"}).
           to_match "^%-%-%-%s+one%s*\n%.%.%.%s*\n%-%-%-%s+two%s*\n%.%.%.%s*$"
@@ -42,6 +42,7 @@ specify lyaml:
         expect (lyaml.dump {"a string"}).to_be "--- a string\n...\n"
         expect (lyaml.dump {"'a string'"}).to_be "--- '''a string'''\n...\n"
         expect (lyaml.dump {"a\nmultiline\nstring"}).to_be "--- |-\n  a\n  multiline\n  string\n...\n"
+        expect (lyaml.dump {""}).to_be "--- ''\n...\n"
 
   - context sequences:
     - it writes a sequence:
@@ -49,8 +50,8 @@ specify lyaml:
 
   - context mappings:
     - it writes a mapping: |
-        expect (lyaml.dump {{a=1, b=2, c=3}}).
-          to_contain.all_of {"a: 1", "b: 2", "c: 3"}
+        expect (lyaml.dump {{a=1, b=2, c=3, d=""}}).
+          to_contain.all_of {"a: 1", "b: 2", "c: 3", "d: ''"}
 
   - context anchors and aliases:
     - before:
@@ -88,10 +89,10 @@ specify lyaml:
 
   - context documents:
     - it lyaml.loads an empty document:
-        expect (fn "---").to_equal {""}
-        expect (fn "---\n").to_equal {""}
-        expect (fn "---\n...").to_equal {""}
-        expect (fn "---\n...\n").to_equal {""}
+        expect (fn "---").to_equal {lyaml.null}
+        expect (fn "---\n").to_equal {lyaml.null}
+        expect (fn "---\n...").to_equal {lyaml.null}
+        expect (fn "---\n...\n").to_equal {lyaml.null}
     - it lyaml.loads multiple documents:
         expect (fn "one\n---\ntwo").to_equal {"one", "two"}
         expect (fn "---\none\n---\ntwo").to_equal {"one", "two"}
@@ -99,17 +100,17 @@ specify lyaml:
         expect (fn "---\none\n...\n---\ntwo\n...").to_equal {"one", "two"}
     - it reports an empty document:
         expect (fn "---\n---\ntwo\n---").
-          to_equal {"", "two", ""}
+          to_equal {lyaml.null, "two", lyaml.null}
         expect (fn "---\n...\n---\ntwo\n---").
-          to_equal {"", "two", ""}
+          to_equal {lyaml.null, "two", lyaml.null}
         expect (fn "---\n...\n---\ntwo\n...\n---").
-          to_equal {"", "two", ""}
+          to_equal {lyaml.null, "two", lyaml.null}
         expect (fn "---\n...\n---\ntwo\n...\n---\n...").
-          to_equal {"", "two", ""}
+          to_equal {lyaml.null, "two", lyaml.null}
 
   - context version directive:
     - it recognizes version number:
-        expect (fn "%YAML 1.1\n---").to_equal {""}
+        expect (fn "%YAML 1.1\n---").to_equal {lyaml.null}
     - it diagneses missing document start:
         expect (fn "%YAML 1.1").
           to_error "expected <document start>"
@@ -136,7 +137,8 @@ specify lyaml:
 
   - context scalars:
     - it recognizes null: '
-        expect (fn "~").to_equal {lyaml.null}'
+        expect (fn "~").to_equal {lyaml.null}
+        expect (fn "foo: ").to_equal {{foo = lyaml.null}}'
     - it recognizes booleans: '
         expect (fn "yes").to_equal {true}
         expect (fn "true").to_equal {true}
@@ -167,6 +169,8 @@ specify lyaml:
         expect (fn "a string").to_equal {"a string"}
         expect (fn "'''a string'''").to_equal {"'a string'"}
         expect (fn "|-\n  a\n  multiline\n  string").to_equal {"a\nmultiline\nstring"}
+        expect (fn "''").to_equal {""}
+        expect (fn '""').to_equal {""}
 
     - context global tags:
       - it recognizes !!null:
@@ -215,8 +219,8 @@ specify lyaml:
 
   - context sequences:
      - it recognizes block sequences:
-         expect (fn "- ~\n- true\n- 42").
-           to_equal {{lyaml.null, true, 42}}
+         expect (fn "- ~\n- \n- true\n- 42").
+           to_equal {{lyaml.null, lyaml.null, true, 42}}
      - it recognizes flow sequences:
          expect (fn "[~, true, 42]").
            to_equal {{lyaml.null, true, 42}}


### PR DESCRIPTION
According to the [spec](http://yaml.org/type/null.html) an empty value should be null. lyaml was previously treating empty values as empty strings which isn't correct.

This change means that `lyaml.load("foo: ")` will now be parsed as `{ foo = lyaml.null }` instead of `{ foo = "" }`.

This also adjusts how real empty string values are dumped, since they need to be quoted rather than an empty value. So `lyaml.dump({{ foo = "" }})` will now be dumped as `foo: ''` instead of `foo: `.

This does change a number of existing tests that involved empty documents now becoming nulls, rather than empty strings, but I've verified that the new behavior seems to match Ruby's YAML library in all these cases. Here's a few examples of these empty document changes (I updated the lyaml test suite accordingly):

```
> YAML.load_stream("---")
=> [nil]
> YAML.load_stream("---\n...\n---\ntwo\n...\n---\n...")
=> [nil, "two", nil]
> YAML.dump("")
=> "--- ''\n"
```

I've also added new tests to explicitly check the null handling for empty values. Here's also a few more examples verifying the new null behavior against the Ruby YAML library:

```
> YAML.load_stream("foo: ")
=> [{"foo"=>nil}]
> YAML.load_stream("- ~\n- \n- true\n- 42")
=> [[nil, nil, true, 42]]
> YAML.load_stream("''")
=> [""]
```

So while this change is backwards incompatible with previous lyaml usage, I believe it should bring the null handling in line with the specification for empty values. Let me know if you have any questions or feedback. Thanks!