### PR TITLE
Fix "required symbol" issue

### DIFF
--- a/lyaml-git-1.rockspec
+++ b/lyaml-git-1.rockspec
@@ -32,6 +32,7 @@ build = {
       .. ' version="' .. _MODREV .. '"'
       .. ' PREFIX="$(PREFIX)"'
       .. ' CFLAGS="$(CFLAGS)"'
+      .. ' LIBS="-lyaml"'
       .. ' LIBFLAG="$(LIBFLAG)"'
       .. ' LIB_EXTENSION="$(LIB_EXTENSION)"'
       .. ' OBJ_EXTENSION="$(OBJ_EXTENSION)"'


### PR DESCRIPTION
REF #30 
I found there is no `-lyaml` parameter when luke is doing compiling, this will cause many "required symbol" issues while building other luarocks.