### PR TITLE
Fixed emiiter not getting `plain_implicit` and `quoted_implicit` from lua (#36)

### DIFF
--- a/ext/yaml/emitter.c
+++ b/ext/yaml/emitter.c
@@ -276,6 +276,8 @@ emit_SCALAR (lua_State *L, lyaml_emitter *emitter)
    RAWGET_YAML_CHARP (anchor); lua_pop (L, 1);
    RAWGET_YAML_CHARP (tag);    lua_pop (L, 1);
    RAWGET_YAML_CHARP (value);  length = lua_objlen (L, -1); lua_pop (L, 1);
+   RAWGET_BOOLEAN (plain_implicit);
+   RAWGET_BOOLEAN (quoted_implicit);
 
    yaml_scalar_event_initialize (&event, anchor, tag, value, length,
       plain_implicit, quoted_implicit, yaml_style);

--- a/spec/ext_yaml_emitter_spec.yaml
+++ b/spec/ext_yaml_emitter_spec.yaml
@@ -209,6 +209,21 @@ specify emitting:
                     {type = "SCALAR", style = "FOLDED", value = "thud"},
                     "DOCUMENT_END"}).
          to_contain ">-\n  thud\n"
+  - it understands plain_implicit:
+      expect (emit {"DOCUMENT_START",
+                    {type = "SCALAR", style = "PLAIN", value = "hello", plain_implicit=false},
+                    "DOCUMENT_END"}).
+         to_contain "'hello'\n"
+  - it understands quoted_implicit:
+      expect (emit {"DOCUMENT_START",
+                    {type = "SCALAR", style = "PLAIN", value = "- world", quoted_implicit=false},
+                    "DOCUMENT_END"}).
+         to_contain "! '- world'\n"
+  - it understands tag:
+      expect (emit {"DOCUMENT_START",
+                    {type = "SCALAR", style = "PLAIN", value = "bug_squash", tag="tagger", plain_implicit=false, quoted_implicit=false},
+                    "DOCUMENT_END"}).
+         to_contain "!<tagger> bug_squash\n"
 
 - describe ALIAS:
   - it diagnoses missing anchor parameter:


### PR DESCRIPTION
Fixed emiiter not getting `plain_implicit` and `quoted_implicit` from lua

Issue Ref: #36 