### PR TITLE
Prevent losing entries with mixed key tables

### DIFF
--- a/spec/lib_lyaml_spec.yaml
+++ b/spec/lib_lyaml_spec.yaml
@@ -50,11 +50,20 @@ specify lyaml:
   - context sequences:
     - it writes a sequence:
         expect (lyaml.dump {{1, 2, 3}}).to_contain "- 1\n- 2\n- 3"
+    - it writes a sequence containing nils: |
+        expect (lyaml.dump {{1, 2, nil, 3, 4}}).
+           to_contain.all_of {"1: 1", "2: 2", "4: 3", "5: 4"}
 
   - context mappings:
     - it writes a mapping: |
         expect (lyaml.dump {{a=1, b=2, c=3, d=""}}).
            to_contain.all_of {"a: 1", "b: 2", "c: 3", "d: ''"}
+    - it writes a mapping of mixed keys: |
+        expect (lyaml.dump {{[1]=1, [2]=2, three="three", four="4", [5]="five"}}).
+           to_contain.all_of {"1: 1", "2: 2", "three: three", "four: '4'", "5: five"}
+    - it writes a mapping of integer keys: |
+        expect (lyaml.dump {{[2]=2, [3]=3, [4]=4, five=5}}).
+           to_contain.all_of {"2: 2", "3: 3", "4: 4", "five: 5"}
 
   - context anchors and aliases:
     - before:

--- a/spec/lib_lyaml_spec.yaml
+++ b/spec/lib_lyaml_spec.yaml
@@ -50,9 +50,6 @@ specify lyaml:
   - context sequences:
     - it writes a sequence:
         expect (lyaml.dump {{1, 2, 3}}).to_contain "- 1\n- 2\n- 3"
-    - it writes a sequence containing nils: |
-        expect (lyaml.dump {{1, 2, nil, 3, 4}}).
-           to_contain.all_of {"1: 1", "2: 2", "4: 3", "5: 4"}
 
   - context mappings:
     - it writes a mapping: |
@@ -61,9 +58,18 @@ specify lyaml:
     - it writes a mapping of mixed keys: |
         expect (lyaml.dump {{[1]=1, [2]=2, three="three", four="4", [5]="five"}}).
            to_contain.all_of {"1: 1", "2: 2", "three: three", "four: '4'", "5: five"}
-    - it writes a mapping of integer keys: |
-        expect (lyaml.dump {{[2]=2, [3]=3, [4]=4, five=5}}).
-           to_contain.all_of {"2: 2", "3: 3", "4: 4", "five: 5"}
+    - it writes a mapping of integer keys starting at two: |
+        expect (lyaml.dump {{[2]=2, [3]=3, [4]=4}}).
+           to_contain.all_of {"2: 2", "3: 3", "4: 4"}
+    - it writes a mapping of mixed keys starting at one: |
+        expect (lyaml.dump {{[1]=1, [2]=2, [3]=3, foo="bar"}}).
+           to_contain.all_of {"1: 1", "2: 2", "3: 3", "foo: bar"}
+    - it writes a mapping of mixed keys starting at two: |
+        expect (lyaml.dump {{[2]=2, [3]=3, [4]=4, foo="bar"}}).
+           to_contain.all_of {"2: 2", "3: 3", "4: 4", "foo: bar"}
+    - it writes a table containing nils (jumps in index) as mapping: |
+        expect (lyaml.dump {{1, 2, nil, 3, 4}}).
+           to_contain.all_of {"1: 1", "2: 2", "4: 3", "5: 4"}
 
   - context anchors and aliases:
     - before:


### PR DESCRIPTION
Hi, currently, the serialization is losing entries when serializing tables with a mix of integer keys and string keys or non consecutive integer keys.

Take the example:
```lua
local lyaml   = require "lyaml"
local test = {}
test[1] = "one"
test[2] = "two"
test["three"] = "three"
print(lyaml.dump({test}))
```

This prints:
```yaml
---
- one
- two
...
```
Thereby dropping the `three: "three"` entry, I would argue that the expected behaviour is preserving all entries in the table and thus serializing this as a mapping instead of a sequence.

First commit commit that introduces unit tests contain mixed keys and fail. The second commit makes the check [here](https://github.com/gvvaughan/lyaml/blob/master/lib/lyaml/init.lua#L202) more stringent, by only using sequences if the table only has integer keys that are sequential, start at one and don't skip any values. At first I tried to compare `#node` with the number of elements in the table, but that is broken for cases such as `t` in the following snippet:
```lua
local t = {}
t[2] = 2
t[3] = 3
t[4] = 4
t.foo = "bar"

local t2 = {[2]=2, [3]=3, [4]=4, ["foo"] = "bar"}
```
Where the count `#t` will be equal to the number of elements, but it should still be serialized as a mapping. I couldn't actually get `t` into the unit test system being used in this package. I instead added `t2`, but these are not equivalent, `#t` is equal to `4`, whereas `#t2` is equal to `0`. In commit three I added some more unit tests.

All testing done on Lua 5.3 (installed via apt) on Focal, initially also installed this module from apt.