### PR TITLE
Fix memory leak in emitter

### DIFF
--- a/ext/yaml/emitter.c
+++ b/ext/yaml/emitter.c
@@ -184,6 +184,8 @@ emit_MAPPING_START (lua_State *L, lyaml_emitter *emitter)
    }
 #undef MENTRY
 
+   if (style) free ((void *) style);
+
    RAWGET_YAML_CHARP (anchor); lua_pop (L, 1);
    RAWGET_YAML_CHARP (tag);    lua_pop (L, 1);
    RAWGET_BOOLEAN (implicit);  lua_pop (L, 1);
@@ -226,6 +228,8 @@ emit_SEQUENCE_START (lua_State *L, lyaml_emitter *emitter)
                              "invalid sequence style '%s'", style));
    }
 #undef MENTRY
+
+   if (style) free ((void *) style);
 
    RAWGET_YAML_CHARP (anchor); lua_pop (L, 1);
    RAWGET_YAML_CHARP (tag);    lua_pop (L, 1);
@@ -272,6 +276,8 @@ emit_SCALAR (lua_State *L, lyaml_emitter *emitter)
                              "invalid scalar style '%s'", style));
    }
 #undef MENTRY
+
+   if (style) free ((void *) style);
 
    RAWGET_YAML_CHARP (anchor); lua_pop (L, 1);
    RAWGET_YAML_CHARP (tag);    lua_pop (L, 1);


### PR DESCRIPTION
For every map, sequence and scalar emitted, lyaml leaks six bytes, because the mapping style parameter is `strdup()`-ed but not freed.

This issue was first reported in #35.

The test code included in that report consistently showed leaks under at least lua5.1 and luajit 2.1.0-beta3; the following version under tighter GC settings makes the issue more visible though:

```lua
collectgarbage("setpause", 103)
collectgarbage("setstepmul", 1600)
local yaml=require("lyaml")
print(collectgarbage("count"),"kb")
for i = 1, 10 do
    for j=1,1000 do
        yaml.dump({a="b", c = {1, 2, 3}, d = {{3, 2, 1}, true, false}})
    end
    print(collectgarbage("count"),"kb")
    collectgarbage()
    print(collectgarbage("count"),"kb")
end
```

Fixed by freeing `style` analogously to `encoding` and `type`.