### PR TITLE
Geert56

### DIFF
--- a/lib/lyaml/init.lua
+++ b/lib/lyaml/init.lua
@@ -473,6 +473,7 @@ end
 -- @tfield boolean all load all documents from the stream
 -- @tfield table explicit_scalar map full tag-names to parser functions
 -- @tfield function implicit_scalar parse implicit scalar values
+-- @tfield boolean distinct_sequence adds dummy metatable to empty sequence
 
 
 --- Load a YAML stream into a Lua table.

--- a/lib/lyaml/init.lua
+++ b/lib/lyaml/init.lua
@@ -396,6 +396,10 @@ local parser_mt = {
             end
             sequence[#sequence + 1] = node
          end
+	 -- Distinguish empty collections from mappings with a metatable.
+	 if self.distinct_sequence and #sequence == 0 then
+	   return setmetatable({}, {}), self:type()
+	 end
          return sequence, self:type()
       end,
 
@@ -456,6 +460,7 @@ local function Parser(s, opts)
       anchors = {},
       explicit_scalar = opts.explicit_scalar,
       implicit_scalar = opts.implicit_scalar,
+      distinct_sequence = opts.distinct_sequence,
       mark = {line=0, column=0},
       next = yaml.parser(s),
    }
@@ -487,6 +492,7 @@ local function load(s, opts)
    local parser = Parser(s, {
       explicit_scalar = opts.explicit_scalar or default.explicit_scalar,
       implicit_scalar = opts.implicit_scalar or default.implicit_scalar,
+      distinct_sequence = opts.distinct_sequence,
    })
 
    if parser:parse() ~= 'STREAM_START' then


### PR DESCRIPTION
Merely adding an option to load() to distinguish empty sequences from empty mappings in the returned Lua table.
Otherwise both would be represented by an empty Lua table. This is by the way still the case, however for an empty
sequence, the Lua table will have an attached empty metatable. This presence can be tested with getmetatable().
So even with the option distinct_sequence set to true, any existing application code will not be affected unless it is
attaching metatables to (some components of) the returned Lua table.