### PR TITLE
Fixed gcc 15.1.1 warnings from -W -Wall -Wextra.

### DIFF
--- a/ext/yaml/emitter.c
+++ b/ext/yaml/emitter.c
@@ -47,13 +47,12 @@ static int
 emit_STREAM_START (lua_State *L, lyaml_emitter *emitter)
 {
    yaml_event_t event;
-   yaml_encoding_t yaml_encoding;
+   yaml_encoding_t yaml_encoding = YAML_ANY_ENCODING;
    const char *encoding = NULL;
 
    RAWGET_STRDUP (encoding); lua_pop (L, 1);
 
 #define MENTRY(_s) (STREQ (encoding, #_s)) { yaml_encoding = YAML_##_s##_ENCODING; }
-   if (encoding == NULL) { yaml_encoding = YAML_ANY_ENCODING; } else
    if MENTRY( UTF8	) else
    if MENTRY( UTF16LE	) else
    if MENTRY( UTF16BE	) else
@@ -79,6 +78,7 @@ emit_STREAM_START (lua_State *L, lyaml_emitter *emitter)
 static int
 emit_STREAM_END (lua_State *L, lyaml_emitter *emitter)
 {
+   (void) L;
    yaml_event_t event;
    yaml_stream_end_event_initialize (&event);
    return yaml_emitter_emit (&emitter->emitter, &event);
@@ -165,7 +165,7 @@ static int
 emit_MAPPING_START (lua_State *L, lyaml_emitter *emitter)
 {
    yaml_event_t event;
-   yaml_mapping_style_t yaml_style;
+   yaml_mapping_style_t yaml_style = YAML_ANY_MAPPING_STYLE;
    yaml_char_t *anchor = NULL, *tag = NULL;
    int implicit = 1;
    const char *style = NULL;
@@ -173,7 +173,6 @@ emit_MAPPING_START (lua_State *L, lyaml_emitter *emitter)
    RAWGET_STRDUP (style);  lua_pop (L, 1);
 
 #define MENTRY(_s) (STREQ (style, #_s)) { yaml_style = YAML_##_s##_MAPPING_STYLE; }
-   if (style == NULL) { yaml_style = YAML_ANY_MAPPING_STYLE; } else
    if MENTRY( BLOCK	) else
    if MENTRY( FLOW	) else
    {
@@ -184,13 +183,12 @@ emit_MAPPING_START (lua_State *L, lyaml_emitter *emitter)
    }
 #undef MENTRY
 
-   if (style) free ((void *) style);
-
    RAWGET_YAML_CHARP (anchor); lua_pop (L, 1);
    RAWGET_YAML_CHARP (tag);    lua_pop (L, 1);
    RAWGET_BOOLEAN (implicit);  lua_pop (L, 1);
 
    yaml_mapping_start_event_initialize (&event, anchor, tag, implicit, yaml_style);
+   if (style) free ((void *) style);
    return yaml_emitter_emit (&emitter->emitter, &event);
 }
 
@@ -199,6 +197,7 @@ emit_MAPPING_START (lua_State *L, lyaml_emitter *emitter)
 static int
 emit_MAPPING_END (lua_State *L, lyaml_emitter *emitter)
 {
+   (void) L;
    yaml_event_t event;
    yaml_mapping_end_event_initialize (&event);
    return yaml_emitter_emit (&emitter->emitter, &event);
@@ -210,7 +209,7 @@ static int
 emit_SEQUENCE_START (lua_State *L, lyaml_emitter *emitter)
 {
    yaml_event_t event;
-   yaml_sequence_style_t yaml_style;
+   yaml_sequence_style_t yaml_style = YAML_ANY_SEQUENCE_STYLE;
    yaml_char_t *anchor = NULL, *tag = NULL;
    int implicit = 1;
    const char *style = NULL;
@@ -218,7 +217,6 @@ emit_SEQUENCE_START (lua_State *L, lyaml_emitter *emitter)
    RAWGET_STRDUP (style);  lua_pop (L, 1);
 
 #define MENTRY(_s) (STREQ (style, #_s)) { yaml_style = YAML_##_s##_SEQUENCE_STYLE; }
-   if (style == NULL) { yaml_style = YAML_ANY_SEQUENCE_STYLE; } else
    if MENTRY( BLOCK	) else
    if MENTRY( FLOW	) else
    {
@@ -229,13 +227,12 @@ emit_SEQUENCE_START (lua_State *L, lyaml_emitter *emitter)
    }
 #undef MENTRY
 
-   if (style) free ((void *) style);
-
    RAWGET_YAML_CHARP (anchor); lua_pop (L, 1);
    RAWGET_YAML_CHARP (tag);    lua_pop (L, 1);
    RAWGET_BOOLEAN (implicit);  lua_pop (L, 1);
 
    yaml_sequence_start_event_initialize (&event, anchor, tag, implicit, yaml_style);
+   if (style) free ((void *) style);
    return yaml_emitter_emit (&emitter->emitter, &event);
 }
 
@@ -244,6 +241,7 @@ emit_SEQUENCE_START (lua_State *L, lyaml_emitter *emitter)
 static int
 emit_SEQUENCE_END (lua_State *L, lyaml_emitter *emitter)
 {
+   (void) L;
    yaml_event_t event;
    yaml_sequence_end_event_initialize (&event);
    return yaml_emitter_emit (&emitter->emitter, &event);
@@ -255,7 +253,7 @@ static int
 emit_SCALAR (lua_State *L, lyaml_emitter *emitter)
 {
    yaml_event_t event;
-   yaml_scalar_style_t yaml_style;
+   yaml_scalar_style_t yaml_style = YAML_ANY_SCALAR_STYLE;
    yaml_char_t *anchor = NULL, *tag = NULL, *value;
    int length = 0, plain_implicit = 1, quoted_implicit = 1;
    const char *style = NULL;
@@ -263,7 +261,6 @@ emit_SCALAR (lua_State *L, lyaml_emitter *emitter)
    RAWGET_STRDUP (style);  lua_pop (L, 1);
 
 #define MENTRY(_s) (STREQ (style, #_s)) { yaml_style = YAML_##_s##_SCALAR_STYLE; }
-   if (style == NULL) { yaml_style = YAML_ANY_SCALAR_STYLE; } else
    if MENTRY( PLAIN		) else
    if MENTRY( SINGLE_QUOTED	) else
    if MENTRY( DOUBLE_QUOTED	) else

--- a/ext/yaml/emitter.c
+++ b/ext/yaml/emitter.c
@@ -78,8 +78,8 @@ emit_STREAM_START (lua_State *L, lyaml_emitter *emitter)
 static int
 emit_STREAM_END (lua_State *L, lyaml_emitter *emitter)
 {
-   (void) L;
    yaml_event_t event;
+   (void) L;
    yaml_stream_end_event_initialize (&event);
    return yaml_emitter_emit (&emitter->emitter, &event);
 }
@@ -197,8 +197,8 @@ emit_MAPPING_START (lua_State *L, lyaml_emitter *emitter)
 static int
 emit_MAPPING_END (lua_State *L, lyaml_emitter *emitter)
 {
-   (void) L;
    yaml_event_t event;
+   (void) L;
    yaml_mapping_end_event_initialize (&event);
    return yaml_emitter_emit (&emitter->emitter, &event);
 }
@@ -241,8 +241,8 @@ emit_SEQUENCE_START (lua_State *L, lyaml_emitter *emitter)
 static int
 emit_SEQUENCE_END (lua_State *L, lyaml_emitter *emitter)
 {
-   (void) L;
    yaml_event_t event;
+   (void) L;
    yaml_sequence_end_event_initialize (&event);
    return yaml_emitter_emit (&emitter->emitter, &event);
 }

--- a/ext/yaml/parser.c
+++ b/ext/yaml/parser.c
@@ -78,7 +78,7 @@ parse_STREAM_START (lyaml_parser *parser)
 {
 #define EVENTF(_f)	(parser->event.data.stream_start._f)
    lua_State *L = parser->L;
-   const char *encoding;
+   const char *encoding = NULL;
 
    switch (EVENTF (encoding))
    {
@@ -182,7 +182,7 @@ parse_SCALAR (lyaml_parser *parser)
 {
 #define EVENTF(_f)	(parser->event.data.scalar._f)
    lua_State *L = parser->L;
-   const char *style;
+   const char *style = NULL;
 
    switch (EVENTF (style))
    {
@@ -219,7 +219,7 @@ parse_SEQUENCE_START (lyaml_parser *parser)
 {
 #define EVENTF(_f)	(parser->event.data.sequence_start._f)
    lua_State *L = parser->L;
-   const char *style;
+   const char *style = NULL;
 
    switch (EVENTF (style))
    {
@@ -249,7 +249,7 @@ parse_MAPPING_START (lyaml_parser *parser)
 {
 #define EVENTF(_f)	(parser->event.data.mapping_start._f)
    lua_State *L = parser->L;
-   const char *style;
+   const char *style = NULL;
 
    switch (EVENTF (style))
    {
@@ -311,7 +311,6 @@ static int
 event_iter (lua_State *L)
 {
    lyaml_parser *parser = (lyaml_parser *)lua_touserdata(L, lua_upvalueindex(1));
-   char *str;
 
    parser_delete_event (parser);
    if (yaml_parser_parse (&parser->parser, &parser->event) != 1)

--- a/ext/yaml/scanner.c
+++ b/ext/yaml/scanner.c
@@ -80,7 +80,7 @@ scan_STREAM_START (lyaml_scanner *scanner)
 {
 #define EVENTF(_f)	(scanner->token.data.stream_start._f)
    lua_State *L = scanner->L;
-   const char *encoding;
+   const char *encoding = NULL;
 
    switch (EVENTF (encoding))
    {
@@ -167,7 +167,7 @@ scan_SCALAR (lyaml_scanner *scanner)
 {
 #define EVENTF(_f)	(scanner->token.data.scalar._f)
    lua_State *L = scanner->L;
-   const char *style;
+   const char *style = NULL;
 
    switch (EVENTF (style))
    {
@@ -230,7 +230,6 @@ static int
 token_iter (lua_State *L)
 {
    lyaml_scanner *scanner = (lyaml_scanner *)lua_touserdata(L, lua_upvalueindex(1));
-   char *str;
 
    scanner_delete_token (scanner);
    if (yaml_parser_scan (&scanner->parser, &scanner->token) != 1)


### PR DESCRIPTION
I'm getting a really weird issue with memory corruption somehow related to lyaml and steam runtimes, so I decided to see if fixing the lyaml warnings on compilation (compiled and embedded with meson instead of luarocks) fixes the issue.