### PR TITLE
compat with Lua 5.4 & 5.5

### DIFF
--- a/ext/yaml/yaml.c
+++ b/ext/yaml/yaml.c
@@ -57,7 +57,11 @@ luaopen_yaml (lua_State *L)
    parser_init (L);
    scanner_init (L);
 
+#if LUA_VERSION_NUM >= 502
+   luaL_newlib(L, R);
+#else
    luaL_register(L, "yaml", R);
+#endif
 
    lua_pushliteral(L, MYVERSION);
    lua_setfield(L, -2, "version");


### PR DESCRIPTION
`luaL_register` is a part of the Lua 5.1 C API.
There is a macro for compatibility in Lua 5.2 & 5.3.
`luaL_newlib` is available since Lua 5.2.